### PR TITLE
convert custom instructions to json before storing in frontmatter

### DIFF
--- a/src/metadata_extraction.py
+++ b/src/metadata_extraction.py
@@ -154,6 +154,10 @@ def build_metadata_block(metadata: dict[str, Any]) -> str:
 
     block_parts: list[str] = ["---"]
 
+    # longer custom instructions break the obsidian frontmatter.
+    custom_instructions = json.dumps(f"""about_user_message: {syv(metadata.get('about_user_message'))}
+        about_model_message: {syv(metadata.get('about_model_message'))}""")
+
     metadata_mapping: dict[str, str] = {
         "chat_link": f'chat_link: "https://chat.openai.com/c/{metadata["id"]}"',
         "title": f"title: {syv(metadata['title'])}",
@@ -164,9 +168,7 @@ def build_metadata_block(metadata: dict[str, Any]) -> str:
         "code_messages": f"code_messages: {syv(metadata['code_messages'])}",
         "message_types": f"message_types: {syv(', '.join(metadata['message_types']))}",
         "used_plugins": f"used_plugins: {syv(', '.join(metadata['used_plugins']))}",
-        "custom_instructions": f"""custom_instructions:
-  about_user_message: {syv(metadata.get('about_user_message'))}
-  about_model_message: {syv(metadata.get('about_model_message'))}""",
+        "custom_instructions": f"custom_instructions: {custom_instructions}",
     }
 
     for key, value in metadata_mapping.items():


### PR DESCRIPTION
I have this in my custom instructions:
```
- Provide accurate and factual answers
- Provide detailed explanations
- Be highly organized
- You are an expert on all subject matters
- No need to disclose you are an AI, e.g., do not answer with "As a large language model..." or "As an artificial intelligence..."
- Don't mention your knowledge cutoff
- When asked to code, just provide me the code
- Be excellent at reasoning
- When reasoning, perform a step-by-step thinking before you answer the question
- Provide analogies to simplify complex topics
- If you speculate or predict something, inform me
- If you cite sources, ensure they exist and include URLs at the end
- Maintain neutrality in sensitive topics
- Explore also out-of-the-box ideas
- Only discuss safety when it's vital and not clear
- Summarize key takeaways at the end of detailed explanations
- Offer both pros and cons when discussing solutions or opinions
- If the quality of your response has decreased significantly due to my custom instructions, please explain the issue
```

Which futzes with the how the Obsidian frontmatter behaves for properties, so I am dumping this to json before adding it to the frontmatter