### PR TITLE
feat: support split conversation files in ChatGPT exports + handle null conversation titles

### DIFF
--- a/convoviz/exceptions.py
+++ b/convoviz/exceptions.py
@@ -6,9 +6,9 @@ class ConvovizError(Exception):
 
 
 class InvalidZipError(ConvovizError):
-    """Raised when a ZIP file is invalid or missing conversations.json."""
+    """Raised when a ZIP file is invalid or missing conversation data."""
 
-    def __init__(self, path: str, reason: str = "missing conversations.json") -> None:
+    def __init__(self, path: str, reason: str = "missing conversation data") -> None:
         self.path = path
         self.reason = reason
         super().__init__(f"Invalid ZIP file '{path}': {reason}")

--- a/convoviz/models/conversation.py
+++ b/convoviz/models/conversation.py
@@ -6,7 +6,7 @@ Object path: conversations.json -> conversation (one of the list items)
 from datetime import datetime, timedelta
 from typing import Any
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel, PrivateAttr, field_validator
 
 from convoviz.models.message import AuthorRole
 from convoviz.models.node import Node, build_node_tree, node_sort_key
@@ -19,8 +19,13 @@ class Conversation(BaseModel):
     This is a pure data model - rendering and I/O logic are in separate modules.
     """
 
-    title: str
+    title: str = ""
     create_time: datetime
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def _coerce_null_title(cls, v: Any) -> str:
+        return v if v is not None else ""
     update_time: datetime
     mapping: dict[str, Node]
     current_node: str

--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -3,7 +3,11 @@
 > **Note**: This changelog is informal and incomplete. It tracks the primary record of all functional and behavioral updates to Convoviz.
 > **APPEND-ONLY. DO NOT EDIT, REWRITE, OR DELETE PAST ENTRIES. ALL NEW UPDATES MUST BE ADDED TO THE TOP.**
 
-## Recent Updates (February 14, 2026)
+## Recent Updates (February 23, 2026)
+
+- **Split conversation file support**: Loaders now accept both single-file (`conversations.json`) and split-file (`conversations-000.json` through `conversations-NNN.json`) ChatGPT export formats. ZIP validation, ZIP loading, and directory loading all handle both formats transparently, merging split files via `ConversationCollection.update()`.
+
+## February 14, 2026
 
 - **Citation Footnotes**: Message citations now render as footnote references in text (`[^n]`) with resolved source definitions emitted at the bottom of each message block, instead of inline links.
 - **Citation Numbering/Deduping**: Footnote numbering now follows source appearance order across indexed and embedded citation formats and reuses numbers for repeated identical sources.

--- a/docs/dev/HANDOFF.md
+++ b/docs/dev/HANDOFF.md
@@ -59,6 +59,8 @@ get_default_config() → ConvovizConfig
 #### Data Flow
 ```
 Input (ZIP/Dir/JSON) → loaders.py → ConversationCollection
+    └── Accepts single conversations.json or split conversations-NNN.json files
+    └── Split files are loaded and merged via ConversationCollection.update()
     └── Contains list of Conversation objects
     └── Sets source_path for asset resolution
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,50 @@ def mock_zip_file(mock_conversations_json, tmp_path):
     return zip_path
 
 
+@pytest.fixture
+def second_conversation_data() -> dict:
+    """Return a second conversation dict distinct from mock_conversation_data."""
+    ts = DATETIME_111.timestamp() + 600
+    return {
+        "title": "conversation 222",
+        "create_time": ts,
+        "update_time": ts + 300,
+        "mapping": {
+            "root_node_222": make_root_node("root_node_222", ["user_node_222"]),
+            "user_node_222": make_message_node(
+                "user_node_222",
+                "user",
+                "user message 222",
+                "root_node_222",
+                ["assistant_node_222"],
+                ts,
+            ),
+            "assistant_node_222": make_message_node(
+                "assistant_node_222",
+                "assistant",
+                "assistant message 222",
+                "user_node_222",
+                [],
+                ts + 60,
+            ),
+        },
+        "current_node": "assistant_node_222",
+        "conversation_id": "conversation_222",
+    }
+
+
+@pytest.fixture
+def mock_multi_zip_file(
+    mock_conversation_data: dict, second_conversation_data: dict, tmp_path: Path
+):
+    """Create a ZIP with split conversation files (conversations-000/001.json)."""
+    zip_path = tmp_path / "multi_export.zip"
+    with ZipFile(zip_path, "w") as zf:
+        zf.writestr("conversations-000.json", json.dumps([mock_conversation_data]))
+        zf.writestr("conversations-001.json", json.dumps([second_conversation_data]))
+    return zip_path
+
+
 # =============================================================================
 # Additional Conversation Fixtures
 # =============================================================================

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -23,7 +23,7 @@ class TestInvalidZipError:
         """Test error message format."""
         error = InvalidZipError("/path/to/file.zip")
         assert "/path/to/file.zip" in str(error)
-        assert "missing conversations.json" in str(error)
+        assert "missing conversation data" in str(error)
 
     def test_custom_reason(self) -> None:
         """Test error with custom reason."""


### PR DESCRIPTION
- Fixes #47
- Fixes #48

## Summary

ChatGPT now splits large exports across multiple numbered files
(`conversations-000.json` through `conversations-NNN.json`) instead of a
single `conversations.json`. Convoviz was hardcoded to expect the
single-file format, causing `InvalidZipError` for these exports.

Additionally, some real-world exports contain conversations with `null`
titles, which caused a Pydantic `ValidationError` during loading.

## Changes

### Split conversation file support (`convoviz/io/loaders.py`)

- Added `_find_conversation_files()` helper that checks for
  `conversations.json` first, then falls back to globbing
  `conversations-NNN.json` files
- Added `_has_conversation_entries()` for ZIP validation against both formats
- Added `_load_from_conversation_files()` that loads and merges split files
  via `ConversationCollection.update()`
- Updated `validate_zip`, `load_collection_from_zip`, and `load_collection`
  to use the new helpers
- Single-file format continues to work exactly as before

### Null title tolerance (`convoviz/models/conversation.py`)

- Added a `field_validator` on `Conversation.title` that coerces `None` to
  `""`, preventing `ValidationError` on real exports with untitled
  conversations

### Other

- Updated `InvalidZipError` default message from "missing
  conversations.json" to "missing conversation data"
- Updated `find_latest_valid_zip` docstring to reflect both formats
- Added test fixtures and 5 new test cases covering split-file validation,
  loading, merging, and single-file preference

## Test plan

- [x] All existing tests pass (262/262)
- [x] New split-file tests pass
- [x] `ruff check` clean
- [x] `ty check` clean
- [x] `ruff format` clean
- [x] Manually tested against a real split-file ChatGPT export
