### PR TITLE
fix: default message status/weight for newer ChatGPT exports

### DIFF
--- a/convoviz/models/message.py
+++ b/convoviz/models/message.py
@@ -69,9 +69,10 @@ class Message(BaseModel):
     create_time: datetime | None = None
     update_time: datetime | None = None
     content: MessageContent
-    status: str
+    # ChatGPT exports from ~July 2026 omit status/weight on some messages
+    status: str = "finished_successfully"
     end_turn: bool | None = None
-    weight: float
+    weight: float = 1.0
     metadata: MessageMetadata = Field(default_factory=MessageMetadata)
     recipient: str | None = None
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -145,6 +145,20 @@ def test_internal_citation_map_ignores_non_dict_ref_id() -> None:
     assert msg.internal_citation_map == {}
 
 
+def test_message_missing_status_and_weight_uses_defaults() -> None:
+    """Test that messages without status/weight validate (July 2026 exports)."""
+    msg = Message.model_validate(
+        {
+            "id": "msg",
+            "author": {"name": None, "role": "tool", "metadata": {}},
+            "content": {"content_type": "text", "parts": ["hello"]},
+            "metadata": {},
+        }
+    )
+    assert msg.status == "finished_successfully"
+    assert msg.weight == 1.0
+
+
 def test_conversation_citation_map_aggregates_metadata_groups() -> None:
     """Test that citation_map aggregates from metadata.search_result_groups."""
     ts = datetime(2024, 1, 1, tzinfo=UTC).timestamp()


### PR DESCRIPTION
New ChatGPT exports omit the status and weight fields on some messages, causing a pydantic ValidationError that aborts loading entirely. Default them to the values older exports always carried.

Fixes #60


More details (from Claude):

## Problem

ChatGPT export ZIPs generated around July 2026 omit the `status` and `weight`
fields on some messages (apparently tool/system nodes). Since `Message`
declares both as required, loading a fresh export raises a single giant
pydantic `ValidationError` (1,286 errors in my export) and the conversion
aborts entirely.

## Fix

Give the two fields defaults matching what older exports always contained:

- `status: str = "finished_successfully"`
- `weight: float = 1.0`

These are safe defaults for rendering: `weight` is only used to rank
regenerated branches, and `status` is mainly consulted to hide DALL-E
status chatter. Every other field on the model already had a default or
was optional — these were the only strict holdouts.


## Testing
- Added a regression test validating a message dict missing both fields
  (shaped like the new exports, including `"name": None` in the author).
- Full suite passes: 290 tests.
- Verified end-to-end against the actual failing export from #60
  (122 MB ZIP, 2026-07-06): previously crashed with 1,286 validation
  errors, now converts cleanly — 1,887 Markdown files, graphs, and
  wordclouds generated.